### PR TITLE
[FEAT] CardBase 공통 컴포넌트 구현

### DIFF
--- a/src/components/common/cardbase/CardBase.tsx
+++ b/src/components/common/cardbase/CardBase.tsx
@@ -1,0 +1,31 @@
+import styled from "styled-components";
+
+export const CardBase = styled.article`
+  display: flex;
+  width: 100%;
+  height: auto;
+  min-height: 120px;
+  flex-direction: column;
+
+  background-color: var(--color-white);
+  border-radius: 16px;
+  border: 1px solid var(--color-gray-200);
+  align-items: flex-start;
+
+  padding: 16px;
+  gap: 12px;
+  transition: all 0.2s ease-in-out;
+
+  color: var(--color-text);
+  box-shadow: 0 4px 20px 0 rgba(0, 0, 0, 0.04);
+
+  //모바일 터치 시 발생하는 기본 회색 하이라이트 제거
+  -webkit-tap-highlight-color: transparent;
+  cursor: pointer;
+
+  &:active {
+    transform: scale(0.98);
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.04);
+    background-color: var(--color-gray-100);
+  }
+`;


### PR DESCRIPTION
## 📣 Related Issue
- close #5 

## 📝 Summary
러닝 세션 정보 등을 표시하는 카드 형태의 공통 컨테이너 `CardBase`를 구현했습니다.
모바일 웹/앱 환경에서의 사용자 경험(UX)을 최우선으로 고려하여 스타일을 적용했습니다.

- **공통 레이아웃 구현**: 내부 콘텐츠의 유연한 배치를 위해 Flexbox(`column`)와 `gap` 속성을 활용했습니다.
- **모바일 인터랙션 강화**: `hover` 대신 터치 시 반응하는 `:active` 상태에 축소 효과(`scale(0.98)`)와 배경색 변경을 적용하여 '눌리는 느낌'을 주었습니다.
- **네이티브 경험 제공**: 모바일 터치 시 발생하는 기본 회색 하이라이트(`-webkit-tap-highlight-color`)를 제거하여 깔끔한 UI를 구현했습니다.
- **방어적 스타일링**: 콘텐츠 양에 따라 높이가 자연스럽게 늘어나도록 `min-height`와 `height: auto`를 설정했습니다.

## 🖼 스크린샷(UI 변경시)

## 🙏 Question & PR point
- **모바일 터치감**: 모바일 뷰에서 카드를 터치했을 때의 인터랙션(눌림 효과)이 과하지 않고 자연스러운지 확인 부탁드립니다.
- **이벤트 버블링**: 해당 카드는 `article` 태그를 사용하며, 내부 버튼이 추가될 경우 `e.stopPropagation()` 처리가 필요할 수 있다는 점 참고 부탁드립니다.
- **레이아웃**: 다양한 길이의 텍스트가 들어갔을 때 패딩과 간격이 적절한지 봐주시면 감사하겠습니다.

## 📬 Reference