### PR TITLE
[FIX] SearchPage 무한 렌더링 수정 및 위치 재요청(refetch) 기능 추가

### DIFF
--- a/src/components/common/kakaomap/KaKaoMap.tsx
+++ b/src/components/common/kakaomap/KaKaoMap.tsx
@@ -95,7 +95,7 @@ export const KaKaoMap = ({
   onZoomChanged,
 }: KaKaoMapProps) => {
   // 내 위치 가져오기
-  const { location, error } = useGeolocation();
+  const { location, error, refetch } = useGeolocation();
   const [map, setMap] = useState<kakao.maps.Map | null>(null);
 
   const [initCenter, setInitCenter] = useState<{
@@ -128,16 +128,16 @@ export const KaKaoMap = ({
 
   // 내 위치 찾기 버튼 핸들러
   const handleMyLocationClick = useCallback(() => {
-    if (!location.x || !location.y) {
-      alert("위치 정보를 가져올 수 없습니다.");
-      return;
-    }
-    if (map) {
+    refetch();
+
+    if (location.x && location.y && map) {
       map.panTo(
         new kakao.maps.LatLng(location.y as number, location.x as number),
       );
+    } else if (!location.x && !location.y) {
+      alert("위치 정보를 가져올 수 없습니다.");
     }
-  }, [location.x, location.y, map]); // map과 location이 바뀔 때만 재생성
+  }, [location.x, location.y, map, refetch]);
 
   // 지도 클릭 핸들러
   const handleMapClick = useCallback(


### PR DESCRIPTION
## 📣 Related Issue
- close #34 

## 📝 Summary
- **`useGeolocation` 커스텀 훅 리팩토링 및 최적화**
  - `options` 객체 의존성으로 인한 무한 렌더링 문제를 `useRef`를 사용하여 해결했습니다.
  - 초기 로딩과 재요청(Refetch) 로딩 상태를 분리하여 `Cascading Render` 에러를 수정했습니다.
  - 외부에서 위치를 다시 요청할 수 있도록 `refetch` 함수를 반환값에 추가했습니다.

- **`KaKaoMap` 컴포넌트 기능 개선**
  - '내 위치' 버튼 클릭 시 단순히 지도 중심만 이동하는 것이 아니라, `refetch`를 호출하여 **실제 최신 위치 정보**를 갱신하도록 수정했습니다.

## 🖼 스크린샷(UI 변경시)

## 🙏 Question & PR point
- **무한 렌더링 해결 로직 (`useGeolocation.ts`)**
  - `useEffect`의 의존성 배열에서 `options` 객체가 계속 새로운 참조값을 만들어내는 문제를 막기 위해 `useRef`로 값을 유지하도록 변경했습니다. 이 부분이 사이드 이펙트 없이 잘 동작하는지 확인 부탁드립니다.
  
- **위치 재요청 UX (`KaKaoMap.tsx`)**
  - '내 위치' 버튼을 누르면 `refetch()`를 통해 GPS를 다시 잡는 동시에, 즉각적인 반응을 위해 기존에 알고 있던 위치로 `panTo`를 먼저 수행하도록 했습니다. 이 하이브리드 방식이 UX적으로 자연스러운지 봐주시면 좋겠습니다.

## 📬 Reference
