### PR TITLE
[REFACTOR] CreateSession 페이지 내 불필요한 지도 렌더링 수정

### DIFF
--- a/src/pages/CreateSession.tsx
+++ b/src/pages/CreateSession.tsx
@@ -51,9 +51,9 @@ export default function CreateSession() {
   );
 
   // 지도 클릭 시 경로에 좌표 추가
-  const handleMapClick = (lat: number, lng: number) => {
+  const handleMapClick = useCallback((lat: number, lng: number) => {
     setRouteNodes((prev) => [...prev, { lat, lng }]);
-  };
+  }, []);
 
   // 시작점 마커 드래그 종료 시 경로의 첫 번째 좌표 갱신
   const handleStartMarkerDragEnd = useCallback((lat: number, lng: number) => {
@@ -61,6 +61,25 @@ export default function CreateSession() {
       prev.length ? [{ lat, lng }, ...prev.slice(1)] : [{ lat, lng }],
     );
   }, []);
+
+  // 마커 배열 참조 안정화 (지도 불필요 리렌더 방지)
+  const markers = useMemo(
+    () =>
+      routeNodes[0]
+        ? [
+            {
+              id: "start" as const,
+              lat: routeNodes[0].lat,
+              lng: routeNodes[0].lng,
+              draggable: true,
+              onDragEnd: handleStartMarkerDragEnd,
+            },
+          ]
+        : [],
+    [routeNodes, handleStartMarkerDragEnd],
+  );
+
+  const routePath = routeNodes.length >= 2 ? routeNodes : undefined;
 
   return (
     <Layout header={pageHeader} scrollable={false}>
@@ -71,21 +90,8 @@ export default function CreateSession() {
           locationBtnBottom="620px"
           isCreateMode={true}
           onMapClick={handleMapClick}
-          routePath={routeNodes.length >= 2 ? routeNodes : undefined}
-          markers={
-            routeNodes[0]
-              ? [
-                  {
-                    // 시작점 마커 (말풍선 없음, 드래그로 위치 이동 가능)
-                    id: "start",
-                    lat: routeNodes[0].lat,
-                    lng: routeNodes[0].lng,
-                    draggable: true,
-                    onDragEnd: handleStartMarkerDragEnd,
-                  },
-                ]
-              : []
-          }
+          routePath={routePath}
+          markers={markers}
         />
         <SessionBottomSheet
           ref={bottomSheetRef}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #36 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- CreateSession 페이지에서 지도(KaKaoMap)가 불필요하게 계속 리렌더되던 현상 해결
- `handleMapClick`을 `useCallback`으로 감싸 참조를 고정하여, 매 렌더마다 새 함수가 KaKaoMap에 전달되지 않도록 수정
- `markers` prop을 `useMemo`로 메모이제이션하여, 시작점 좌표(`firstLat`, `firstLng`)와 `handleStartMarkerDragEnd`가 바뀔 때만 새 배열이 생성되도록 수정
- `routePath`를 변수로 분리하여 가독성 정리

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야 할 사항이나 궁금증을 적어주세요 -->
- 기존 "러닝 세션 개설" 페이지에서 지도가 늦게 렌더링되는 문제 해결했습니다.